### PR TITLE
Add flag to show only the first line of an inline script

### DIFF
--- a/src/it/quiet-script/invoker.properties
+++ b/src/it/quiet-script/invoker.properties
@@ -1,0 +1,79 @@
+###
+# #%L
+# Beanshell Maven Plugin
+# %%
+# Copyright (C) 2014 - 2017 Günther Enthaler
+# %%
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# #L%
+###
+
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project
+invoker.goals.1 = bsh:run
+
+# Optionally, a list of goals to run during further invocations of Maven
+#invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:run
+
+# A comma or space separated list of profiles to activate
+#invoker.profiles = its,jdk15
+
+# The path to an alternative POM or base directory to invoke Maven on, defaults to the
+# project that was originally specified in the plugin configuration
+# Since plugin version 1.4
+#invoker.project = sub-module
+
+# The value for the environment variable MAVEN_OPTS
+#invoker.mavenOpts = -Dfile.encoding=UTF-16 -Xms32m -Xmx256m
+
+# Possible values are "fail-fast" (default), "fail-at-end" and "fail-never"
+#invoker.failureBehavior = fail-never
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+#invoker.buildResult = failure
+
+# A boolean value controlling the aggregator mode of Maven, defaults to "false"
+#invoker.nonRecursive = true
+
+# A boolean value controlling the network behavior of Maven, defaults to "false"
+# Since plugin version 1.4
+#invoker.offline = true
+
+# The path to the properties file from which to load system properties, defaults to the
+# filename given by the plugin parameter testPropertiesFile
+# Since plugin version 1.4
+#invoker.systemPropertiesFile = test.properties
+
+# An optional human friendly name for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.name = Beanshell Maven Plugin quiet test
+
+# An optional description for this build job to be included in the build reports.
+# Since plugin version 1.4
+invoker.description = Test the quiet mode (print only first line of script)
+
+# A comma separated list of JRE versions on which this build job should be run.
+# Since plugin version 1.4
+#invoker.java.version = 1.4+, !1.4.1, 1.7-
+
+# A comma separated list of OS families on which this build job should be run.
+# Since plugin version 1.4
+#invoker.os.family = !windows, unix, mac
+
+# A comma separated list of Maven versions on which this build should be run.
+# Since plugin version 1.5
+#invoker.maven.version = 2.0.10+, !2.1.0, !2.2.0
+
+# A boolean value controlling the debug logging level of Maven, , defaults to "false"
+# Since plugin version 1.8
+#invoker.debug = true

--- a/src/it/quiet-script/pom.xml
+++ b/src/it/quiet-script/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #%L
+  Beanshell Maven Plugin
+  %%
+  Copyright (C) 2014 - 2017 Günther Enthaler
+  %%
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  
+       http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  #L%
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.github.genthaler</groupId>
+	<artifactId>@project.artifactId@-test</artifactId>
+	<version>@project.version@</version>
+	<packaging>pom</packaging>
+	<name>@project.name@ POM Test</name>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>@project.groupId@</groupId>
+				<artifactId>@project.artifactId@</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<id>default-cli</id>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<inherited>false</inherited>
+						<configuration>
+							<script><![CDATA[
+							System.out.println("First line");
+							System.out.println("Second line");
+							]]></script>
+							<quiet>true</quiet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/src/it/quiet-script/verify.groovy
+++ b/src/it/quiet-script/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * #%L
+ * Beanshell Maven Plugin
+ * %%
+ * Copyright (C) 2014 - 2017 Günther Enthaler
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+File logFile = new File( basedir, "build.log" )
+
+assert logFile.isFile()
+
+String logContent = logFile.text
+assert logContent.contains("System.out.println(\"First line\"); [+ 1 omitted line(s)]")
+assert !logContent.contains("System.out.println(\"Second line\");")
+assert logContent.contains("First line")
+assert logContent.contains("Second line")

--- a/src/main/scripts/run.bsh
+++ b/src/main/scripts/run.bsh
@@ -2,7 +2,7 @@
  * #%L
  * Beanshell Maven Plugin
  * %%
- * Copyright (C) 2014 - 2016 Günther Enthaler
+ * Copyright (C) 2014 - 2017 Günther Enthaler
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,12 @@ execute()
         logger.info( "interpreting file " + file);
     	this.interpreter.source(file);
     } else if (script.getClass() == String.class) {
-        logger.info( "evaluating script " + script);
+        if (quiet.getClass() == String.class && Boolean.valueOf(quiet)) {
+            String[] scriptLines = script.split("\\n");
+            logger.info( "evaluating script " + scriptLines[0] + " [+ " + (scriptLines.length - 1) + " omitted line(s)]" );
+        } else {
+            logger.info( "evaluating script " + script);
+        }
     	this.interpreter.eval(script);
     }
 }
@@ -66,6 +71,16 @@ setScript( String s )
 setFile( File f )
 {
     file = f;
+}
+
+/**
+ * Quiet mode: only show the first line of the script to evaluate
+ *
+ * @parameter expression="${bsh.quiet}" type="java.lang.String" default-value="false"
+ */
+setQuiet( String s )
+{
+    quiet = s;
 }
 
 /**


### PR DESCRIPTION
Hi, and thanks for the plugin!

This PR introduces an optional ``quiet`` parameter, which when set to ``true`` only logs the first line of a script, with an indication of the full length.

Rationale is that when scripts from a POM file run on several lines, the output of the whole script content to the build console tends to add clutter, especially when the same script (e.g from a parent POM) is run on a multi-module project.